### PR TITLE
直接忽略整个类

### DIFF
--- a/MJExtension/NSObject+MJClass.h
+++ b/MJExtension/NSObject+MJClass.h
@@ -22,7 +22,8 @@ typedef NSArray * (^MJAllowedCodingPropertyNames)(void);
 typedef NSArray * (^MJIgnoredPropertyNames)(void);
 /** 这个数组中的属性名将会被忽略：不进行归档 */
 typedef NSArray * (^MJIgnoredCodingPropertyNames)(void);
-
+/** 这个数组中的类名将会被忽略*/
+typedef NSArray * (^MJIgnoredClassNames)(void);
 /**
  * 类相关的扩展
  */
@@ -58,6 +59,18 @@ typedef NSArray * (^MJIgnoredCodingPropertyNames)(void);
  *  这个数组中的属性名将会被忽略：不进行字典和模型的转换
  */
 + (NSMutableArray *)mj_totalIgnoredPropertyNames;
+
+/**
+ 这个数组中的父类会被忽略,不进行模型转换
+
+ @param ignoreClassNames 这个数组中的父类会被忽略,不进行模型转换
+ */
++ (void)mj_setupIgnoredClassNames:(MJIgnoredClassNames)ignoreClassNames;
+
+/**
+ 这个数组中的父类会被忽略,不进行模型转换
+ */
++ (NSMutableArray *)mj_totalIgnoredClassNames;
 
 #pragma mark - 归档属性白名单配置
 /**

--- a/MJExtension/NSObject+MJClass.m
+++ b/MJExtension/NSObject+MJClass.m
@@ -16,6 +16,7 @@ static const char MJAllowedPropertyNamesKey = '\0';
 static const char MJIgnoredPropertyNamesKey = '\0';
 static const char MJAllowedCodingPropertyNamesKey = '\0';
 static const char MJIgnoredCodingPropertyNamesKey = '\0';
+static const char MJIgnoredClassNamesKey = '\0';
 
 @implementation NSObject (MJClass)
 
@@ -83,6 +84,15 @@ static const char MJIgnoredCodingPropertyNamesKey = '\0';
         // 4.2.获得父类
         c = class_getSuperclass(c);
     }
+}
+
+#pragma mark - 类黑名单配置
++ (void)mj_setupIgnoredClassNames:(MJIgnoredClassNames)ignoreClassNames {
+    [self mj_setupBlockReturnValue:ignoreClassNames key:&MJIgnoredClassNamesKey];
+}
+
++ (NSMutableArray *)mj_totalIgnoredClassNames {
+    return [self mj_totalObjectsWithSelector:@selector(mj_ignoredClassNames) key:&MJIgnoredClassNamesKey];
 }
 
 #pragma mark - 属性黑名单配置

--- a/MJExtension/NSObject+MJKeyValue.h
+++ b/MJExtension/NSObject+MJKeyValue.h
@@ -27,6 +27,11 @@
 + (NSArray *)mj_ignoredPropertyNames;
 
 /**
+ 这个数组中的类将被忽略
+ */
++ (NSArray *)mj_ignoredClassNames;
+
+/**
  *  将属性名换为其他key去字典中取值
  *
  *  @return 字典中的key是属性名，value是从字典中取值用的key

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -354,10 +354,14 @@ static const char MJReferenceReplacedKeyWhenCreatingKeyValuesKey = '\0';
     Class clazz = [self class];
     NSArray *allowedPropertyNames = [clazz mj_totalAllowedPropertyNames];
     NSArray *ignoredPropertyNames = [clazz mj_totalIgnoredPropertyNames];
-    
+    NSArray *ignoredClassNames = [clazz mj_totalIgnoredClassNames];
+
     [clazz mj_enumerateProperties:^(MJProperty *property, BOOL *stop) {
         @try {
             // 0.检测是否被忽略
+            if ([ignoredClassNames containsObject:NSStringFromClass(property.srcClass)]) {
+                return;
+            }
             if (allowedPropertyNames.count && ![allowedPropertyNames containsObject:property.name]) return;
             if ([ignoredPropertyNames containsObject:property.name]) return;
             if (keys.count && ![keys containsObject:property.name]) return;


### PR DESCRIPTION
直接忽略整个类，适用于父类有很多属性需要全部忽略不进行转换的时候